### PR TITLE
Changes for move/rename of modbus code etc.

### DIFF
--- a/panel.c
+++ b/panel.c
@@ -4,7 +4,6 @@
 
   Part of grblHAL
 
-  Copyright (c) 2020-2021 Terje Io
   Copyright (c) 2021-2023 Jon Escombe
 
   Grbl is free software: you can redistribute it and/or modify
@@ -24,7 +23,7 @@
 
 #include "panel.h"
 
-#if PANEL_ENABLE
+#if PANEL_ENABLE == 1 || PANEL_ENABLE == 2
 
 #include <math.h>
 #include <string.h>
@@ -34,10 +33,14 @@
 #include "../grbl/hal.h"
 #include "../grbl/state_machine.h"
 #include "../grbl/report.h"
+#include "../grbl/nvs_buffer.h"
+#include "../grbl/protocol.h"
 #else
 #include "grbl/hal.h"
 #include "grbl/state_machine.h"
 #include "grbl/report.h"
+#include "grbl/nvs_buffer.h"
+#include "grbl/protocol.h"
 #endif
 
 #if PANEL_ENABLE == 1 && !(MODBUS_ENABLE)

--- a/panel.h
+++ b/panel.h
@@ -4,7 +4,6 @@
 
   Part of grblHAL
 
-  Copyright (c) 2020 Terje Io
   Copyright (c) 2021 Jon Escombe
 
   Grbl is free software: you can redistribute it and/or modify
@@ -27,11 +26,13 @@
 
 #ifdef ARDUINO
 #include "../driver.h"
-#include "../grbl/nvs_buffer.h"
+//#include "../grbl/nvs_buffer.h"
 #else
 #include "driver.h"
-#include "grbl/nvs_buffer.h"
+//#include "grbl/nvs_buffer.h"
 #endif
+
+#if PANEL_ENABLE == 1 || PANEL_ENABLE == 2
 
 #include <stdio.h>
 
@@ -39,8 +40,11 @@
 #include "canbus/canbus.h"
 #endif
 
+#if GRBL_BUILD >= 20230610
+#include "spindle/modbus_rtu.h"
+#else
 #include "spindle/modbus.h"
-#include "spindle/vfd/spindle.h"
+#endif
 
 #include "keypad_bitfields.h"
 #include "canbus_ids.h"
@@ -153,6 +157,6 @@ typedef struct {
 } panel_settings_t;
 
 
-void panel_init ();
+#endif /* PANEL_ENABLE == 1 || PANEL_ENABLE == 2 */
 
 #endif /* _PANEL_H_ */


### PR DESCRIPTION
I will add a call to `panel_init()` in the next core commit, however I will make the call reusable by other implementations by assigning PANEL_ENABLE 1 and 2 to this. Others will have to use different values.

I have moved some `#includes` and removed `#include "spindle/vfd/spindle.h"` from _panel.h_ as nothing from this is used? I may be wrong about that though.

If everything works out ok it should soon be possible to add 3rd party plugins to the [Web Builder](http://svn.io-engineering.com:8080/), this is one candidate. There is a new tab you can check out to preview this.
Plugin naming is one minor issue I have, I am considering adding the author/repo to the name, e.g. this would become _Panel by @dresco_. What do you think?
